### PR TITLE
DM-10961: Use metasrc's tex comments and whitespace filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - "nvm install node"  # latest version of node
   - "nvm use node"
   - "npm install"
+  - "npm install gulp --global"
   - "pip install -r requirements.txt"
 script:
   - "gulp assets --env=deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ deploy:
     repo: "lsst-sqre/lander"
   skip_upload_docs: true
   distributions: sdist bdist_wheel
+  skip_cleanup: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Change Log
 
 - Detect if running from a Travis PR build (using the ``TRAVIS_PULL_REQUEST`` environment variable) and if so, abort the page build and upload.
   This is to prevent duplicate uploads from both branch and PR-based Travis jobs.
+- Pin inuitcss to 6.0.0-beta4 because of the removal of rem functions in beta5.
 
 [0.1.1] - (2017-06-17)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change Log
 ##########
 
+[0.1.1] - (2017-06-17)
+======================
+
+- Update to ``metasrc>=0.1.1,<0.2``.
+- Use ``remove_comments`` and ``remove_trailing_whitespace`` feature from metasrc.
+  This improves the accuracy of metadata extraction from tex source.
+  For example, comment characters won't appear in extract abstract content.
+
 [0.1.0] - (2017-05-24)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change Log
 ##########
 
+[0.1.2] - (2017-06-27)
+======================
+
+- Detect if running from a Travis PR build (using the ``TRAVIS_PULL_REQUEST`` environment variable) and if so, abort the page build and upload.
+  This is to prevent duplicate uploads from both branch and PR-based Travis jobs.
+
 [0.1.1] - (2017-06-17)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change Log
 ##########
 
+Unreleased
+==========
+
+- Use metasrc 0.1.3,<0.2.0 to for improved LaTeX source processing, including handling of referenced source files and macros.
+
 [0.1.4] - (2017-07-06)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change Log
 ##########
 
+[0.1.4] - (2017-07-06)
+======================
+
+- Fix logic for determining it Lander is running in a Travis PR environment.
+- Log the Lander version at startup.
+
 [0.1.3] - (2017-07-02)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change Log
 ##########
 
+[0.1.3] - (2017-07-02)
+======================
+
+- Fixed Travis deployment issue. Used ``skip_cleanup: true`` to ``.travis.yml`` to prevent CSS and JS assets from bring cleaned up before creating a release.
+
 [0.1.2] - (2017-06-27)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Change Log
 Unreleased
 ==========
 
-- Use metasrc 0.1.3,<0.2.0 to for improved LaTeX source processing, including handling of referenced source files and macros.
+- Use metasrc 0.1.3rc1 to for improved LaTeX source processing, including handling of referenced source files and macros.
 
 [0.1.4] - (2017-07-06)
 ======================

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -95,7 +95,7 @@ gulp.task('icons', function () {
 
 // Runs `lander` render to create development HTML in _build
 gulp.task('html', ['icons'], () => {
-  return run(`lander --pdf tests/data/LDM-nnn.pdf --lsstdoc tests/data/LDM-nnn.tex --build-dir ${dirs.dev} --ltd-product "ldm-nnn" --repo-branch master --repo-url https://github.com/lsst/ldm-nnn.git --extra-downloads tests/data/LDM-nnn.tex --docushare-url "https://ls.st/ldm-nnn*" --date "2017-05-12"`).exec()
+  return run(`lander --pdf tests/data/LDM-nnn.pdf --lsstdoc tests/data/LDM-nnn.tex --build-dir ${dirs.dev} --ltd-product "ldm-nnn" --repo-branch master --repo-url https://github.com/lsst/ldm-nnn.git --extra-downloads tests/data/LDM-nnn.tex --docushare-url "https://ls.st/ldm-nnn*"`).exec()
     .pipe(gulp.dest(`${dirs.dev}/logs`)) // makes the reload synchronous
     .pipe(reload());
 });

--- a/lander/config.py
+++ b/lander/config.py
@@ -98,10 +98,10 @@ class Configuration(object):
             self['git_tag'] = os.getenv('TRAVIS_TAG')
             self['github_slug'] = os.getenv('TRAVIS_REPO_SLUG')
             self['travis_job_number'] = os.getenv('TRAVIS_JOB_NUMBER')
-            if os.getenv('TRAVIS_PULL_REQUEST').lower() == 'true':
-                self['travis_pull_request'] = True
+            if os.getenv('TRAVIS_PULL_REQUEST').lower() == 'false':
+                self['is_travis_pull_request'] = False
             else:
-                self['travis_pull_request'] = False
+                self['is_travis_pull_request'] = True
 
         # Apply metadata overrides
 

--- a/lander/config.py
+++ b/lander/config.py
@@ -98,6 +98,10 @@ class Configuration(object):
             self['git_tag'] = os.getenv('TRAVIS_TAG')
             self['github_slug'] = os.getenv('TRAVIS_REPO_SLUG')
             self['travis_job_number'] = os.getenv('TRAVIS_JOB_NUMBER')
+            if os.getenv('TRAVIS_PULL_REQUEST').lower() == 'true':
+                self['travis_pull_request'] = True
+            else:
+                self['travis_pull_request'] = False
 
         # Apply metadata overrides
 
@@ -214,6 +218,7 @@ class Configuration(object):
             'git_commit': None,
             'git_tag': None,
             'travis_job_number': None,
+            'travis_pull_request': False,  # If not on Travis, not a PR anyways
             'aws_id': None,
             'aws_secret': None,
             'keeper_url': 'https://keeper.lsst.codes',

--- a/lander/config.py
+++ b/lander/config.py
@@ -8,7 +8,8 @@ import re
 import datetime
 
 from metasrc.tex.lsstdoc import LsstDoc
-from metasrc.tex import texnormalizer
+from metasrc.tex.texnormalizer import read_tex_file, replace_macros
+from metasrc.tex.scraper import get_macros
 import structlog
 import dateutil
 
@@ -72,12 +73,11 @@ class Configuration(object):
                 self._logger.error('Cannot find {0}'.format(
                     self['lsstdoc_tex_path']))
                 sys.exit(1)
-            with open(self['lsstdoc_tex_path']) as f:
-                tex_source = f.read()
 
-            # Apply source normalization pipeline
-            tex_source = texnormalizer.remove_comments(tex_source)
-            tex_source = texnormalizer.remove_trailing_whitespace(tex_source)
+            # Read and normalize the TeX source, replacing macros with content
+            tex_source = read_tex_file(self['lsstdoc_tex_path'])
+            tex_macros = get_macros(tex_source)
+            tex_source = replace_macros(tex_source, tex_macros)
 
             # Extract metadata from the LsstDoc document
             lsstdoc = LsstDoc(tex_source)

--- a/lander/config.py
+++ b/lander/config.py
@@ -8,6 +8,7 @@ import re
 import datetime
 
 from metasrc.tex.lsstdoc import LsstDoc
+from metasrc.tex import texnormalizer
 import structlog
 import dateutil
 
@@ -73,16 +74,22 @@ class Configuration(object):
                 sys.exit(1)
             with open(self['lsstdoc_tex_path']) as f:
                 tex_source = f.read()
-                lsstdoc = LsstDoc(tex_source)
-                self['title'] = lsstdoc.title
-                if lsstdoc.abstract is not None:
-                    self['abstract'] = lsstdoc.abstract
-                if lsstdoc.handle is not None:
-                    self['doc_handle'] = lsstdoc.handle
-                    self['series'] = lsstdoc.series
-                    self['series_name'] = self._get_series_name(self['series'])
-                if lsstdoc.authors is not None:
-                    self['authors'] = lsstdoc.authors
+
+            # Apply source normalization pipeline
+            tex_source = texnormalizer.remove_comments(tex_source)
+            tex_source = texnormalizer.remove_trailing_whitespace(tex_source)
+
+            # Extract metadata from the LsstDoc document
+            lsstdoc = LsstDoc(tex_source)
+            self['title'] = lsstdoc.title
+            if lsstdoc.abstract is not None:
+                self['abstract'] = lsstdoc.abstract
+            if lsstdoc.handle is not None:
+                self['doc_handle'] = lsstdoc.handle
+                self['series'] = lsstdoc.series
+                self['series_name'] = self._get_series_name(self['series'])
+            if lsstdoc.authors is not None:
+                self['authors'] = lsstdoc.authors
 
         # Get metadata from Travis environment
         if self['environment'] is not None:

--- a/lander/config.py
+++ b/lander/config.py
@@ -218,7 +218,7 @@ class Configuration(object):
             'git_commit': None,
             'git_tag': None,
             'travis_job_number': None,
-            'travis_pull_request': False,  # If not on Travis, not a PR anyways
+            'is_travis_pull_request': False,  # If not on Travis, not a PR
             'aws_id': None,
             'aws_secret': None,
             'keeper_url': 'https://keeper.lsst.codes',

--- a/lander/main.py
+++ b/lander/main.py
@@ -181,7 +181,7 @@ def main():
     config = Configuration(args=args)
 
     # disable any build confirmed to be a PR with Travis
-    if config['travis_pull_request']:
+    if config['is_travis_pull_request']:
         logger.info('Skipping Travis PR job')
         sys.exit(0)
 

--- a/lander/main.py
+++ b/lander/main.py
@@ -175,8 +175,12 @@ def main():
     logger = structlog.get_logger(__name__)
 
     if args.show_version:
+        # only print the version
         print_version()
         sys.exit(0)
+
+    version = pkg_resources.get_distribution('lander').version
+    logger.info('Lander version {0}'.format(version))
 
     config = Configuration(args=args)
 

--- a/lander/main.py
+++ b/lander/main.py
@@ -179,6 +179,12 @@ def main():
         sys.exit(0)
 
     config = Configuration(args=args)
+
+    # disable any build confirmed to be a PR with Travis
+    if config['travis_pull_request']:
+        logger.info('Skipping Travis PR job')
+        sys.exit(0)
+
     lander = Lander(config)
     lander.build_site()
     logger.info('Build complete')

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "webpack": "^2.5.1"
   },
   "dependencies": {
-    "inuitcss": "^6.0.0-beta.4",
+    "inuitcss": "6.0.0-beta.4",
     "normalize-scss": "^6.0.0",
     "pdfobject": "^2.0.201604172",
     "sass-math-pow": "^0.1.3",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'metasrc>=0.1.0,<0.2.0'
+        'metasrc>=0.1.2,<0.2.0'
     ],
     package_data={'lander': [
         'assets/*.svg',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'metasrc>=0.1.2,<0.2.0'
+        'metasrc>=0.1.3rc1,<0.2.0'
     ],
     package_data={'lander': [
         'assets/*.svg',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'metasrc>=0.1.3rc1,<0.2.0'
+        'metasrc==0.1.3rc1'
     ],
     package_data={'lander': [
         'assets/*.svg',

--- a/tests/data/LDM-nnn.tex
+++ b/tests/data/LDM-nnn.tex
@@ -4,9 +4,11 @@
 
 % Local commands go here
 
-\title[Short title]{Title of document}
+\def \theDocTitle {Title of document}
 
-\author{
+\title[Short title]{\theDocTitle}
+
+\author{%
 A.~Author,
 B.~Author,
 and


### PR DESCRIPTION
This improves metadata extraction from tex document source using the new metasrc 0.1.3.

- Commented tex source and trailing whitespace are cleaned.
- Referenced tex source files (via `\input` and `\include` are inserted into the read tex source.
- Simple macros are resolved (those made with `\def` and `\newcommand`, without arguments)

Also ensures that lander exits without uploading a landing page for Travis PR builds. We only want to deploy landing pages from Travis branch builds.