### PR TITLE
DM-11245: Compute DocuShare URL and draft status with heuristic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,13 @@
 Change Log
 ##########
 
-Unreleased
-==========
+[0.1.5] - (2017-07-12)
+======================
 
-- Use metasrc 0.1.3rc1 to for improved LaTeX source processing, including handling of referenced source files and macros.
+- Pin to metasrc 0.1.3
+- Via metasrc, Lander has improved LaTeX source processing, including handling of referenced source files (``\input`` and ``\include``) and macros (``\def`` and ``\newcommand``).
+- Improved treatment of draft status.
+  The heuristic is that a document is considered a draft if the branch is not ``master`` and ``lsstdraft`` is not present in a lsstdoc document's options.
 
 [0.1.4] - (2017-07-06)
 ======================

--- a/lander/config.py
+++ b/lander/config.py
@@ -40,7 +40,10 @@ class Configuration(object):
         self._logger = structlog.get_logger(__name__)
 
         # Make dict from argparse namespace
-        self._args = {k: v for k, v in vars(args).items() if v}
+        if args is not None:
+            self._args = {k: v for k, v in vars(args).items() if v}
+        else:
+            self._args = {}
 
         # Holds configuration overrides and computed configurations
         self._configs = dict(config)

--- a/lander/exceptions.py
+++ b/lander/exceptions.py
@@ -1,0 +1,6 @@
+"""Lander exception library.
+"""
+
+
+class DocuShareError(Exception):
+    """Raised when an API request to DocuShare is unsuccessful."""

--- a/lander/templates/_info-panel.jinja
+++ b/lander/templates/_info-panel.jinja
@@ -2,7 +2,7 @@
   <img class="lander-info-header__logo" src="assets/lsst_underline_logo.svg" alt="Large Synoptic Survey Telescope">
   {% if config['doc_handle'] %}
   <span class="lander-info-header__handle">{{ config['doc_handle'] }}
-    {% if config['docushare_url'] %}
+    {% if config['is_draft_branch'] %}
     DRAFT
     {% endif %}
   </span>

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'metasrc==0.1.3rc1'
+        'metasrc==0.1.3'
     ],
     package_data={'lander': [
         'assets/*.svg',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,3 +27,27 @@ def test_docushare_url_config(doc_handle, expected_url):
         assert config['docushare_url'] is None
     else:
         assert config['docushare_url'] == expected_url
+
+
+@pytest.mark.parametrize(
+    'git_branch, expected',
+    [('u/jonathansick/test', True),
+     ('master', False),
+     ('docushare-v1', False),
+     ('docushare-v10', False),
+     ('docushare-v10-test', True)])
+def test_determine_draft_status(git_branch, expected):
+    assert Configuration._determine_draft_status(git_branch) is expected
+
+
+@pytest.mark.parametrize(
+    'git_branch, expected',
+    [('u/jonathansick/test', True),
+     ('master', False),
+     ('docushare-v1', False),
+     ('docushare-v10', False),
+     ('docushare-v10-test', True)])
+def test_draft_status(git_branch, expected):
+    """Integrated testing of is_draft_branch computation."""
+    config = Configuration(git_branch=git_branch, _validate_pdf=False)
+    assert config['is_draft_branch'] is expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+"""Tests for the lander.config module."""
+
+import pytest
+
+from lander.config import Configuration
+from lander.exceptions import DocuShareError
+
+
+def test_get_docushare_url():
+    url = Configuration._get_docushare_url('LDM-151')
+    assert url == 'https://ls.st/ldm-151*'
+
+
+def test_get_docushare_url_bad_handle():
+    with pytest.raises(DocuShareError):
+        Configuration._get_docushare_url('FOOBAR-1')
+
+
+@pytest.mark.parametrize(
+    'doc_handle, expected_url',
+    [('LDM-151', 'https://ls.st/ldm-151*'),
+     ('FOOBAR-1', None)])
+def test_docushare_url_config(doc_handle, expected_url):
+    """Integrated testing of doc_handle computation."""
+    config = Configuration(doc_handle=doc_handle, _validate_pdf=False)
+    if expected_url is None:
+        assert config['docushare_url'] is None
+    else:
+        assert config['docushare_url'] == expected_url


### PR DESCRIPTION
(Should be merged after #2)

This PR improves handling of DocuShare URLs and heuristics for computing what is considered a draft.

Changes for DocuShare URL handling:

- If not specified with a `--docushare-url` argument, the `docushare_url` configuration is automatically computed from the document's handle. The URL is validated by performing a HEAD request (following redirects).
- The docushare URL pattern is `https://ls.st/ldm-151*` (i.e., to the version page). This allows a user to review metadata about the document on DocuShare before downloading it.

Changes for draft status:

- Add a `is_draft_branch` configuration. The Jinja2 info-panel template uses this variable, not the presence of a DocuShare URL to determine the draft status.
- Draft status is computed with the following heuristic:
  1. Git branch is not `master`
  2. LsstDoc metadata (from metasrc) shows that `lsstdraft` is in the `\documentclass` options.

(There's an interim commit that used a heuristic based on `docushare-vN` branch names, but this isn't applied in the final changeset.)

**Note**: metasrc dependency is temporarily changed to point at metasrc's ticket branch. This needs to be updated before merging.