### PR TITLE
DM-11821: Update to metasrc 0.1.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Change Log
 - Update metasrc to 0.1.4.
   This update provides improved LaTeX command metadata extraction.
   (`DM-11821 <https://jira.lsstcorp.org/browse/DM-11821>`_)
+- Temporarily skip ls.st and DocuShare-related unit tests because ls.st links to DocuShare are broken due to the DocuShare upgrade.
 
 0.1.5 (2017-07-12)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,42 +2,49 @@
 Change Log
 ##########
 
-[0.1.5] - (2017-07-12)
-======================
+0.1.6 (2017-09-07)
+==================
+
+- Update metasrc to 0.1.4.
+  This update provides improved LaTeX command metadata extraction.
+  (`DM-11821 <https://jira.lsstcorp.org/browse/DM-11821>`_)
+
+0.1.5 (2017-07-12)
+==================
 
 - Pin to metasrc 0.1.3
 - Via metasrc, Lander has improved LaTeX source processing, including handling of referenced source files (``\input`` and ``\include``) and macros (``\def`` and ``\newcommand``).
 - Improved treatment of draft status.
   The heuristic is that a document is considered a draft if the branch is not ``master`` and ``lsstdraft`` is not present in a lsstdoc document's options.
 
-[0.1.4] - (2017-07-06)
-======================
+0.1.4 (2017-07-06)
+==================
 
 - Fix logic for determining it Lander is running in a Travis PR environment.
 - Log the Lander version at startup.
 
-[0.1.3] - (2017-07-02)
-======================
+0.1.3 (2017-07-02)
+==================
 
 - Fixed Travis deployment issue. Used ``skip_cleanup: true`` to ``.travis.yml`` to prevent CSS and JS assets from bring cleaned up before creating a release.
 
-[0.1.2] - (2017-06-27)
-======================
+0.1.2 (2017-06-27)
+==================
 
 - Detect if running from a Travis PR build (using the ``TRAVIS_PULL_REQUEST`` environment variable) and if so, abort the page build and upload.
   This is to prevent duplicate uploads from both branch and PR-based Travis jobs.
 - Pin inuitcss to 6.0.0-beta4 because of the removal of rem functions in beta5.
 
-[0.1.1] - (2017-06-17)
-======================
+0.1.1 (2017-06-17)
+==================
 
 - Update to ``metasrc>=0.1.1,<0.2``.
 - Use ``remove_comments`` and ``remove_trailing_whitespace`` feature from metasrc.
   This improves the accuracy of metadata extraction from tex source.
   For example, comment characters won't appear in extract abstract content.
 
-[0.1.0] - (2017-05-24)
-======================
+0.1.0 (2017-05-24)
+==================
 
 Initial version.
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'metasrc==0.1.3'
+        'metasrc==0.1.4'
     ],
     package_data={'lander': [
         'assets/*.svg',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ from lander.config import Configuration
 from lander.exceptions import DocuShareError
 
 
+@pytest.mark.skip(reason='Fails because ls.st+DocuShare is broken (2017-09-07')
 def test_get_docushare_url():
     url = Configuration._get_docushare_url('LDM-151')
     assert url == 'https://ls.st/ldm-151*'
@@ -18,6 +19,7 @@ def test_get_docushare_url_bad_handle():
         Configuration._get_docushare_url('FOOBAR-1')
 
 
+@pytest.mark.skip(reason='Fails because ls.st+DocuShare is broken (2017-09-07')
 @pytest.mark.parametrize(
     'doc_handle, expected_url',
     [('LDM-151', 'https://ls.st/ldm-151*'),


### PR DESCRIPTION
This gets us better LaTeX command parsing via metasrc's LatexCommand class. It parses streams rather than using brittle regular expressions to match a whole command and its content.