### PR TITLE
DM-10928: Improve HTML rendering with new metasrc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change Log
 ##########
 
+0.1.7 (2017-09-28)
+==================
+
+- Update metasrc to 0.2.0.
+  This provides Pandoc integration for improved HTML rendering of content extracted from LaTeX documents.
+- Improve how loggers are configured (warning level for third-party loggers, and info/debug levels for first-party LSST SQuaRE code).
+
 0.1.6 (2017-09-07)
 ==================
 

--- a/lander/config.py
+++ b/lander/config.py
@@ -8,9 +8,7 @@ import re
 import datetime
 import urllib.parse
 
-from metasrc.tex.lsstdoc import LsstDoc
-from metasrc.tex.texnormalizer import read_tex_file, replace_macros
-from metasrc.tex.scraper import get_macros
+from metasrc.tex.lsstdoc import LsstLatexDoc
 import structlog
 import dateutil
 import requests
@@ -87,22 +85,23 @@ class Configuration(object):
                     self['lsstdoc_tex_path']))
                 sys.exit(1)
 
-            # Read and normalize the TeX source, replacing macros with content
-            tex_source = read_tex_file(self['lsstdoc_tex_path'])
-            tex_macros = get_macros(tex_source)
-            tex_source = replace_macros(tex_source, tex_macros)
-
-            # Extract metadata from the LsstDoc document
-            lsstdoc = LsstDoc(tex_source)
+            # Extract metadata from the LsstLatexDoc document
+            lsstdoc = LsstLatexDoc.read(self['lsstdoc_tex_path'])
             self['title'] = lsstdoc.title
+            self['title_html'] = lsstdoc.html_title
+            self['title_plain'] = lsstdoc.plain_title
             if lsstdoc.abstract is not None:
                 self['abstract'] = lsstdoc.abstract
+                self['abstract_html'] = lsstdoc.html_abstract
+                self['abstract_plain'] = lsstdoc.plain_abstract
             if lsstdoc.handle is not None:
                 self['doc_handle'] = lsstdoc.handle
                 self['series'] = lsstdoc.series
                 self['series_name'] = self._get_series_name(self['series'])
             if lsstdoc.authors is not None:
                 self['authors'] = lsstdoc.authors
+                self['authors_html'] = lsstdoc.html_authors
+                self['authors_plain'] = lsstdoc.plain_authors
 
         # Get metadata from Travis environment
         if self['environment'] is not None:
@@ -300,9 +299,9 @@ class Configuration(object):
         ----------
         git_branch : `str`
             Git branch or tag name.
-        lsstdoc : `metasrc.tex.lsstdoc.LsstDoc`
-            `~metasrc.tex.lsstdoc.LsstDoc` instance where, if the ``is_draft``
-            argument is `True`, the draft status is True.
+        lsstdoc : `metasrc.tex.lsstdoc.LsstLatexDoc`
+            `~metasrc.tex.lsstdoc.LsstLatexDoc` instance where, if the
+            ``is_draft`` argument is `True`, the draft status is True.
 
         Returns
         -------

--- a/lander/lander.py
+++ b/lander/lander.py
@@ -29,8 +29,8 @@ class Lander(object):
         self._config['relative_pdf_path'] = relative_pdf_path
 
         # Add data for HTML title/description tags
-        self._config['page_title'] = self._config['title']
-        self._config['page_description'] = self._config['abstract']
+        self._config['page_title'] = self._config['title_plain']
+        self._config['page_description'] = self._config['abstract_plain']
 
         # Copy assets (css, js)
         # This algorithm is slightly naieve; we copy the whole built

--- a/lander/main.py
+++ b/lander/main.py
@@ -201,12 +201,29 @@ def main():
 
 
 def config_logger(args):
-    if args.verbose:
-        level = logging.DEBUG
-    else:
-        level = logging.INFO
-    logging.basicConfig(level=level)
+    # Configure the root logger
+    stream_handler = logging.StreamHandler()
+    stream_formatter = logging.Formatter(
+        '%(asctime)s %(levelname)8s %(name)s | %(message)s')
+    stream_handler.setFormatter(stream_formatter)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(stream_handler)
+    root_logger.setLevel(logging.WARNING)
 
+    # Setup first-party logging
+    app_logger = logging.getLogger('lander')
+    metasrc_logger = logging.getLogger('metasrc')
+    ltdconveyor_logger = logging.getLogger('ltdconveyor')
+    if args.verbose:
+        app_logger.setLevel(logging.DEBUG)
+        metasrc_logger.setLevel(logging.DEBUG)
+        ltdconveyor_logger.setLevel(logging.DEBUG)
+    else:
+        app_logger.setLevel(logging.INFO)
+        metasrc_logger.setLevel(logging.INFO)
+        ltdconveyor_logger.setLevel(logging.INFO)
+
+    # Configure structlog
     structlog.configure(
         processors=[
             structlog.stdlib.filter_by_level,

--- a/lander/templates/_info-panel.jinja
+++ b/lander/templates/_info-panel.jinja
@@ -7,7 +7,7 @@
     {% endif %}
   </span>
   {% endif %}
-  <h1 class="lander-info-header__product-name">{{ config['title'] }}</h1>
+  <h1 class="lander-info-header__product-name">{{ config['title_html']|safe }}</h1>
 
   <ul class="o-list-bare">
     <li>
@@ -59,8 +59,8 @@
 {% if config['authors'] %}
 <section class="lander-info-authors">
   <ul class='comma-list'>
-  {% for author_name in config['authors'] %}
-    <li>{{ author_name }}</li>
+  {% for author_name in config['authors_html'] %}
+    <li>{{ author_name|safe }}</li>
   {% endfor %}
   </ul>
 </section>
@@ -69,7 +69,7 @@
 {% if config['abstract'] %}
 <section class="lander-info-abstract">
   <h2 class="lander-subsection-header">Abstract</h2>
-  {{ config['abstract']|paragraphify }}
+  {{ config['abstract_html']|safe }}
 </section>
 {% endif %}
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'metasrc==0.1.4'
+        'metasrc==0.2.0'
     ],
     package_data={'lander': [
         'assets/*.svg',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from metasrc.tex.lsstdoc import LsstDoc
+from metasrc.tex.lsstdoc import LsstLatexDoc
 
 from lander.config import Configuration
 from lander.exceptions import DocuShareError
@@ -43,7 +43,7 @@ def test_docushare_url_config(doc_handle, expected_url):
      ('docushare-v1', r'\documentclass[DM]{lsstdoc}', False),
      ('docushare-v1', r'\documentclass[DM,lsstdraft]{lsstdoc}', True)])
 def test_determine_draft_status(git_branch, docclass, expected):
-    lsstdoc = LsstDoc(docclass)
+    lsstdoc = LsstLatexDoc(docclass)
     is_draft = Configuration._determine_draft_status(git_branch,
                                                      lsstdoc=lsstdoc)
     assert is_draft == expected
@@ -57,7 +57,7 @@ def test_determine_draft_status(git_branch, docclass, expected):
      ('docushare-v10', True),
      ('docushare-v10-test', True)])
 def test_draft_status(git_branch, expected):
-    """Integrated testing of is_draft_branch computation. LsstDoc metadata
+    """Integrated testing of is_draft_branch computation. LsstLatexDoc metadata
     is not available here, only branch information is used.
     """
     config = Configuration(git_branch=git_branch, _validate_pdf=False)


### PR DESCRIPTION
- Update metasrc to 0.2.0. (https://github.com/lsst-sqre/metasrc/pull/6)
  This provides Pandoc integration for improved HTML rendering of content extracted from LaTeX documents.
- Improve how loggers are configured (warning level for third-party loggers, and info/debug levels for first-party LSST SQuaRE code).