### PR TITLE
DM-12079: Use LsstLatexDoc.revision_datetime API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change Log
 ##########
 
+0.1.8 (2017-10-09)
+==================
+
+- Update metasrc to 0.2.1
+- Use metasrc's ``LsstLatexDoc.revision_datetime`` to obtain the date of a document.
+  This method uses a combination of parsing the ``\date`` LaTeX command, looking at content
+  Git commits, and falling back to 'now' to get an appropriate timestamp.
+
 0.1.7 (2017-09-28)
 ==================
 

--- a/lander/config.py
+++ b/lander/config.py
@@ -90,6 +90,7 @@ class Configuration(object):
             self['title'] = lsstdoc.title
             self['title_html'] = lsstdoc.html_title
             self['title_plain'] = lsstdoc.plain_title
+            self['build_datetime'] = lsstdoc.revision_datetime
             if lsstdoc.abstract is not None:
                 self['abstract'] = lsstdoc.abstract
                 self['abstract_html'] = lsstdoc.html_abstract

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'metasrc==0.2.0'
+        'metasrc==0.2.1'
     ],
     package_data={'lander': [
         'assets/*.svg',


### PR DESCRIPTION
- Update metasrc to 0.2.1
- Use metasrc's `LsstLatexDoc.revision_datetime` to obtain the date of a document. This method uses a combination of parsing the `\date` LaTeX command, looking at content Git commits, and falling back to 'now' to get an appropriate timestamp.