### PR TITLE
DM-12569: Update to metasrc 0.2.2 for fixed Pandoc auto-install

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change Log
 ##########
 
+0.1.9 (2017-11-20)
+==================
+
+- Update metasrc to 0.2.2 to resolve issues with auto-downloading Pandoc in Travis CI (`DM-12569 <https://jira.lsstcorp.org/browse/DM-12569>`_).
+- Update pytest to 3.2.5 and pytest-flake8 to 0.9.1 to fix incompatibilities in the floating indirect dependencies.
+
 0.1.8 (2017-10-09)
 ==================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 -e .
 
 # Development/testing dependencies
-pytest==3.0.7
+pytest==3.2.5
 pytest-cov==2.5.0
-pytest-flake8==0.8.1
+pytest-flake8==0.9.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'metasrc==0.2.1'
+        'metasrc==0.2.2'
     ],
     package_data={'lander': [
         'assets/*.svg',


### PR DESCRIPTION
Note: this branch will be revised to use metasrc 0.2.2 itself once lsst-sqre/metasrc#8 is closed.