### PR TITLE
DM-13512: More robust jsonld generation of the articleBody field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - "pip install -e .[dev]"
 script:
   - "gulp assets --env=deploy"
-  - "pytest"
+  - "make pytest"
 env:
   global:
     - "PYPI_DEPLOY=false"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ Change Log
 ===================
 
 - Update to ``lsst-projectmeta-kit`` 0.3.1 for more reliable ``metadata.jsonld`` generation (works around pandoc issues converting some documents to plain text).
+  There's a new integration test ``make dmtn070`` that demos this.
+- Improve the testing strategy:
+  - Run ``make pytest`` to run pytest with the correct arguments instead of using ``--add-opts`` in setup.cfg.
+    This lets us run ``pytest`` directly with ad hoc arguments.
+  - Run ``make test`` to run both pytest and the integration tests.
 
 0.1.11 (2018-02-07)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change Log
 ##########
 
+0.1.12 (2018-02-10)
+===================
+
+- Update to ``lsst-projectmeta-kit`` 0.3.1 for more reliable ``metadata.jsonld`` generation (works around pandoc issues converting some documents to plain text).
+
 0.1.11 (2018-02-07)
 ===================
 

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,7 @@ help:
 ldm151:
 	# End-to-end smoke integration test with LDM-151
 	bash integration-tests/test_ldm151.bash
+
+dmtn070:
+	# End-to-end smoke integration test with DMTN-070
+	bash integration-tests/test_dmtn070.bash

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
-.PHONY: help ldm151
+.PHONY: help test pytest ldm151 dmtn070
 
 help:
 	@echo "Make command reference"
+	@echo "  make test ........ (run all unit and integration tests)"
+	@echo "  make pytest ...... (run pytest unit tests)"
 	@echo "  make ldm151 ...... (run LDM-151 integration test)"
+	@echo "  make ldm070 ...... (run DMTN-070 integration test)"
+
+test: pytest ldm151 dmtn070
+
+pytest:
+	pytest --flake8 --doctest-modules lander tests
 
 ldm151:
 	# End-to-end smoke integration test with LDM-151

--- a/README.rst
+++ b/README.rst
@@ -130,18 +130,21 @@ Clone and install dependencies (use a Python virtual environment of your choice)
 Run Python tests and linting
 ----------------------------
 
-We use pytest for unit testing::
+We use pytest for unit testing and style checks::
 
-   pytest
+   make pytest
 
-You can also run an end-to-end trial of a landing page build::
+You can also run end-to-end trials of landing page builds::
 
-   make ldm151
+   make test
 
-Build a test site
------------------
+These integration tests clone real LSST documents, compiles them with Docker, and builds landing pages to simulate continuous delivery workflows in production.
+Look for sites in ``_tests``.
 
-The default gulp_ workflow create website assets and generates a test website::
+Build a development site
+------------------------
+
+The default gulp_ workflow creates website assets and generates a test website::
 
    gulp
 

--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,6 @@ With the ``--lsstdoc <tex path>`` argument, Lander will attempt to scrape metada
 - document handle
 - title
 
-Note that Lander does not convert LaTeX commands to HTML.
-In these cases, the metadata needs to be added explicitly.
-We plan to address this in future releases.
-
 See https://lsst-texmf.lsst.io for information about the ``lsstdoc`` class.
 
 Get metadata from the Travis environment

--- a/integration-tests/test_dmtn070.bash
+++ b/integration-tests/test_dmtn070.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+git clone https://github.com/lsst-dm/DMTN-070 _tests/DMTN-070
+cd _tests/DMTN-070
+docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'
+TRAVIS_COMMIT=2aafb1252b4d8b94342db3dfaa381c3d7e80bab7 TRAVIS_BRANCH=master TRAVIS_REPO_SLUG="lsst-dm/dmtn-070" TRAVIS_JOB_NUMBER=11.1 TRAVIS_PULL_REQUEST=false lander --pdf DMTN-070.pdf --lsstdoc DMTN-070.tex --env=travis --ltd-product dmtn-070

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,6 @@ exclude =
   versioneer.py
   lander/_version.py
 
-[tool:pytest]
-addopts = --flake8 --doctest-modules lander tests
-
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'structlog==17.1.0',
         'ltd-conveyor==0.3.1',
         'requests==2.14.2',
-        'lsst-projectmeta-kit==0.3.0'
+        'lsst-projectmeta-kit==0.3.1'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
- Update to lsst-projectmeta-kit 0.3.1. This provides workarounds for cases when pandoc can't process a LaTeX document (DMTN-069 and DMTN-070) are examples of this.
- Add `make test` and `make pytest` targets