### PR TITLE
Add Contributor class, used for authors

### DIFF
--- a/src/lander/ext/parser/__init__.py
+++ b/src/lander/ext/parser/__init__.py
@@ -3,6 +3,7 @@
 __all__ = [
     "DocumentMetadata",
     "Parser",
+    "Contributor",
     "Person",
     "FormattedString",
     "ParsingPlugins",
@@ -15,6 +16,7 @@ __all__ = [
 
 from lander.ext.parser._cidata import CiMetadata, CiPlatform, GitRefType
 from lander.ext.parser._datamodel import (
+    Contributor,
     DocumentMetadata,
     FormattedString,
     Person,

--- a/src/lander/ext/parser/_datamodel.py
+++ b/src/lander/ext/parser/_datamodel.py
@@ -19,7 +19,13 @@ if TYPE_CHECKING:
     CallableGenerator = Generator[AnyCallable, None, None]
 
 
-__all__ = ["FormattedString", "Person", "Orcid", "DocumentMetadata"]
+__all__ = [
+    "FormattedString",
+    "Person",
+    "Contributor",
+    "Orcid",
+    "DocumentMetadata",
+]
 
 WHITESPACE_PATTERN = re.compile(r"\s+")
 
@@ -251,6 +257,17 @@ class Person(BaseModel):
         return collapse_whitespace(v)
 
 
+class Contributor(Person):
+    """Data about a contributor.
+
+    A ``Contributor`` is the same as a ``Person``, with the addition of the
+    `role` attribute.
+    """
+
+    role: Optional[str] = None
+    """Description of the contributor's role."""
+
+
 class DocumentMetadata(BaseModel):
     """A container for LaTeX document metadata."""
 
@@ -263,7 +280,7 @@ class DocumentMetadata(BaseModel):
     abstract: Optional[FormattedString] = None
     """Document abstract or summary."""
 
-    authors: List[Person] = Field(default_factory=lambda: [])
+    authors: List[Contributor] = Field(default_factory=lambda: [])
     """Authors of the document."""
 
     date_modified: Optional[datetime.date] = None


### PR DESCRIPTION
Contributor is a subclass of Person that includes an additional "role" attribute. This role can be used to annotate an author's specific role. This can be useful in some author lists.

The authors attribute of the DocumentMetadata listing now uses the Contributor type.

The original Author class can still be used by plugin-specific subclasses of DocumentMetadata that don't have a need for role metadata and just need to identify a person.