### PR TITLE
Interpret paths in lander.yaml as relative

### DIFF
--- a/src/lander/settings.py
+++ b/src/lander/settings.py
@@ -140,19 +140,25 @@ class BuildSettings(BaseModel):
             settings_data: Dict[str, Any] = yaml.safe_load(
                 settings_path.read_text()
             )
+            project_dir = settings_path.parent
         else:
             settings_data = {}
+            project_dir = Path.cwd()
 
         # Modify the data to convert paths to DownloadableFile tile
         if "pdf" in settings_data:
             settings_data["pdf"] = DownloadableFile.load(
-                Path(settings_data["pdf"])
+                project_dir.joinpath(settings_data["pdf"])
             )
         if "attachments" in settings_data:
             settings_data["attachments"] = [
-                DownloadableFile.load(Path(p))
+                DownloadableFile.load(project_dir.joinpath(p))
                 for p in settings_data["attachments"]
             ]
+        if "source_path" in settings_data:
+            settings_data["source_path"] = project_dir.joinpath(
+                settings_data["source_path"]
+            )
 
         # Adding in command-line overrides
         if output_dir:

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -25,9 +25,9 @@ def test_load_from_cwd(temp_article_dir: Path) -> None:
     settings_path.write_text(yaml.dump(settings_data))
 
     settings = BuildSettings.load(parser="article", theme="minimalist")
-    assert settings.output_dir == Path("_build")
-    assert settings.source_path == Path("article.tex")
-    assert settings.pdf.file_path == Path("article.pdf")
+    assert settings.output_dir.resolve() == Path("_build").resolve()
+    assert settings.source_path.resolve() == Path("article.tex").resolve()
+    assert settings.pdf.file_path.resolve() == Path("article.pdf").resolve()
     assert settings.parser == "article"
     assert settings.theme == "minimalist"
 


### PR DESCRIPTION
If lander is being run not from the same directory as lander.yaml, the relative paths stated in lander.yaml will still resolve.