### PR TITLE
DM-30154: Pin click<8 (for 1.x release branch)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change Log
 ##########
 
+1.0.1 (2021-05-11)
+==================
+
+- Pin click<8 since Click 8.0.0 currently triggers the ``--version`` mode, regardless of whether it was set on the command-line or not.
+
 1.0.0 (2021-01-06)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     requests
     lsst-projectmeta-kit>=0.3.5
     pydantic
+    click<8.0.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Pin click<8 since Click 8.0.0 currently triggers the `--version` mode, regardless of whether it was set on the command-line or not.