### PR TITLE
DM-30364: Update how pandoc is obtained

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,54 @@ jobs:
       - name: Run tests
         run: tox -e py,lint,typing
 
+  demo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Install pandoc
+        run: brew install pandoc
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Read .nvmrc
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+
+      - name: NPM install
+        run: |
+          npm install -g gulp-cli
+          npm install
+
+      - name: Python install
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+          pip install tox
+
+      - name: Build assets
+        run: gulp assets
+
+      - name: Build demo pages
+        run: tox -e demo
+
+      - name: Upload demo artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: article-demo
+          path: _build/article-demo
+
   pypi:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
+      - name: Install pandoc
+        run: brew install pandoc
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -56,6 +59,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Install pandoc
+        run: brew install pandoc
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,7 @@ install_requires =
     email-validator # for pydantic
     bleach
     pypandoc
-    py-pandoc<2.10 # match panflut compatibility matrix
-    panflute~=1.2  # https://github.com/sergiocorreia/panflute#supported-pandoc-versions
+    panflute>=2  # https://github.com/sergiocorreia/panflute#supported-pandoc-versions
     GitPython
     typer
     base32-lib

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Intended Audience :: Developers
     Natural Language :: English
     Operating System :: POSIX

--- a/src/lander/cli.py
+++ b/src/lander/cli.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import typer
 
+from lander.ext.parser.pandoc import print_pandoc_version
 from lander.plugins import parsers, themes
 from lander.settings import BuildSettings
 
@@ -30,6 +31,8 @@ def build(
         None, "--url", help="Canonical URL where the landing page is hosted."
     ),
 ) -> None:
+    print_pandoc_version()
+
     settings = BuildSettings.load(
         output_dir=output,
         source_path=source,

--- a/src/lander/ext/parser/pandoc/__init__.py
+++ b/src/lander/ext/parser/pandoc/__init__.py
@@ -1,5 +1,6 @@
 """Markup conversion functionality, powered by Pandoc."""
 
+from lander.ext.parser.pandoc._compatibility import print_pandoc_version
 from lander.ext.parser.pandoc._convert import convert_text, ensure_pandoc
 
-__all__ = ["convert_text", "ensure_pandoc"]
+__all__ = ["convert_text", "ensure_pandoc", "print_pandoc_version"]

--- a/src/lander/ext/parser/pandoc/_compatibility.py
+++ b/src/lander/ext/parser/pandoc/_compatibility.py
@@ -1,0 +1,13 @@
+"""Pandoc version compatibility checking."""
+
+from __future__ import annotations
+
+import pypandoc
+
+from lander.ext.parser.pandoc._convert import ensure_pandoc
+
+
+@ensure_pandoc
+def print_pandoc_version() -> None:
+    version = pypandoc.get_pandoc_version()
+    print(f"Using pandoc {version}")

--- a/src/lander/ext/parser/pandoc/_convert.py
+++ b/src/lander/ext/parser/pandoc/_convert.py
@@ -38,6 +38,7 @@ def ensure_pandoc(func: F) -> Callable[..., Any]:
                     pypandoc.get_pandoc_version(),
                 )
             except Exception:
+                logger.exception("Failed to download pandoc.")
                 raise RuntimeError(
                     "Could not install Pandoc. Please pre-install pandoc on "
                     "your system and try again. See "

--- a/src/lander/ext/parser/pandoc/_convert.py
+++ b/src/lander/ext/parser/pandoc/_convert.py
@@ -26,8 +26,23 @@ def ensure_pandoc(func: F) -> Callable[..., Any]:
             result = func(*args, **kwargs)
         except OSError:
             # Install pandoc and retry
-            message = "Pandoc is required but not found."
-            logger.warning(message)
+            logger.warning(
+                "Pandoc is required but not found. Lander is going to try to "
+                "install it for you right now."
+            )
+
+            try:
+                pypandoc.download_pandoc()
+                logger.info(
+                    "Pandoc version %s installation complete",
+                    pypandoc.get_pandoc_version(),
+                )
+            except Exception:
+                raise RuntimeError(
+                    "Could not install Pandoc. Please pre-install pandoc on "
+                    "your system and try again. See "
+                    "https://pandoc.org/installing.html."
+                )
 
             result = func(*args, **kwargs)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py37,coverage-report,lint,typing
+envlist = py,coverage-report,lint,typing
 isolated_build = True
 
 [testenv]
@@ -33,3 +33,12 @@ deps =
     mypy
 commands =
     mypy src/lander tests setup.py
+
+[testenv:demo]
+description = Build a demo landing page.
+allowlist_externals =
+    rm
+commands_pre =
+    rm -rf _build/article-demo
+commands =
+    lander build --source tests/data/article-yaml-md/article.tex --pdf tests/data/article-yaml-md/article.pdf --output _build/article-demo --parser article --theme minimalist


### PR DESCRIPTION
py-pandoc -> pypandoc.download_pandoc or allow the user to install pandoc first. In fact, `pypandoc.download_pandoc()` appears to be systematically broken for recent versions of pandoc. Instead, we recommend installing Pandoc in GitHub Actions via Homebrew (apt-get install installs an old and incompatible version of pandoc).

Also, add integration testing in GitHub Actions that uploads the demo site as a CI artifact.