### PR TITLE
DM-45321: Make Parser a generic type

### DIFF
--- a/changelog.d/20240718_152120_jsick_DM_45321.md
+++ b/changelog.d/20240718_152120_jsick_DM_45321.md
@@ -1,0 +1,3 @@
+### New features
+
+- Parser now uses generics to describe the subclass of DocumentMetadata that the parser provides.

--- a/src/lander/ext/parser/_parser.py
+++ b/src/lander/ext/parser/_parser.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from lander.ext.parser._cidata import CiMetadata
 from lander.ext.parser._datamodel import DocumentMetadata
@@ -15,10 +15,13 @@ if TYPE_CHECKING:
     from lander.settings import BuildSettings
 
 
-__all__ = ["Parser"]
+__all__ = ["Parser", "MetadataContainer"]
+
+#: Type variable of the DocumentMetadata Pydantic object being stored in Parser
+MetadataContainer = TypeVar("MetadataContainer", bound=DocumentMetadata)
 
 
-class Parser(metaclass=ABCMeta):
+class Parser(Generic[MetadataContainer], metaclass=ABCMeta):
     """Base class for TeX document metadata parsing extensions.
 
     Parameters
@@ -93,7 +96,7 @@ class Parser(metaclass=ABCMeta):
         return self._git_repository
 
     @property
-    def metadata(self) -> DocumentMetadata:
+    def metadata(self) -> MetadataContainer:
         """Metadata about the document."""
         return self._metadata
 
@@ -115,7 +118,7 @@ class Parser(metaclass=ABCMeta):
         return replace_macros(tex_source, macros)
 
     @abstractmethod
-    def extract_metadata(self) -> DocumentMetadata:
+    def extract_metadata(self) -> MetadataContainer:
         """Extract metadata from the document.
 
         This method should be implemented by parser subclasses.


### PR DESCRIPTION
This allows plugins that implement a `Parser` to describe the subclass of `DocumentMetadata` that they specific parse and provide. This improves type checking for parsing plugins.