### PR TITLE
DM-45321: Make Parser metadata type variable importable

### DIFF
--- a/changelog.d/20240718_160401_jsick_DM_45321.md
+++ b/changelog.d/20240718_160401_jsick_DM_45321.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- The `MetadataContainer` type variable has been renamed to `DocumentMetadataT` and is now available from the `lander.ext.parser` module. This allows subclasses to declare the type variable consistently.

--- a/src/lander/ext/parser/__init__.py
+++ b/src/lander/ext/parser/__init__.py
@@ -2,6 +2,7 @@
 
 __all__ = [
     "DocumentMetadata",
+    "DocumentMetadataT",
     "Parser",
     "Contributor",
     "Person",
@@ -23,4 +24,4 @@ from lander.ext.parser._datamodel import (
 )
 from lander.ext.parser._discovery import ParsingPlugins
 from lander.ext.parser._gitdata import GitFile, GitRepository
-from lander.ext.parser._parser import Parser
+from lander.ext.parser._parser import DocumentMetadataT, Parser

--- a/src/lander/ext/parser/_parser.py
+++ b/src/lander/ext/parser/_parser.py
@@ -15,13 +15,13 @@ if TYPE_CHECKING:
     from lander.settings import BuildSettings
 
 
-__all__ = ["Parser", "MetadataContainer"]
+__all__ = ["Parser", "DocumentMetadataT"]
 
 #: Type variable of the DocumentMetadata Pydantic object being stored in Parser
-MetadataContainer = TypeVar("MetadataContainer", bound=DocumentMetadata)
+DocumentMetadataT = TypeVar("DocumentMetadataT", bound=DocumentMetadata)
 
 
-class Parser(Generic[MetadataContainer], metaclass=ABCMeta):
+class Parser(Generic[DocumentMetadataT], metaclass=ABCMeta):
     """Base class for TeX document metadata parsing extensions.
 
     Parameters
@@ -96,7 +96,7 @@ class Parser(Generic[MetadataContainer], metaclass=ABCMeta):
         return self._git_repository
 
     @property
-    def metadata(self) -> MetadataContainer:
+    def metadata(self) -> DocumentMetadataT:
         """Metadata about the document."""
         return self._metadata
 
@@ -118,7 +118,7 @@ class Parser(Generic[MetadataContainer], metaclass=ABCMeta):
         return replace_macros(tex_source, macros)
 
     @abstractmethod
-    def extract_metadata(self) -> MetadataContainer:
+    def extract_metadata(self) -> DocumentMetadataT:
         """Extract metadata from the document.
 
         This method should be implemented by parser subclasses.


### PR DESCRIPTION
The `MetadataContainer` type variable has been renamed to
`DocumentMetadataT` and is now available from the `lander.ext.parser`
module. This allows subclasses to declare the type variable
consistently.