### PR TITLE
DM-52424: Fix setting --date from the command line

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3
@@ -59,7 +59,6 @@ jobs:
         run: which pandoc | true
 
   pypi:
-
     runs-on: ubuntu-latest
     needs: [test]
     if: startsWith(github.ref, 'refs/tags/')

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  }
+}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change Log
 ##########
 
+1.0.8 (2025-09-09)
+==================
+
+- Fix setting the date metadata from the command line ``--date`` argument.
+- Add Python 3.13 to the list of supported versions.
+- Add a setuptools to <81 dependency to provide ``pkg_resources`` for some environments.
+
 1.0.6 (2023-07-04)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     pytz
     aiohttp
     GitPython
+    setuptools<81  # for pkg_resources
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Intended Audience :: Developers
     Natural Language :: English
     Operating System :: POSIX

--- a/src/lander/config.py
+++ b/src/lander/config.py
@@ -118,7 +118,7 @@ def build_configuration(
     configs.update(cli_configs)
 
     # Build and validation configurations
-    return Configuration(**configs)
+    return Configuration.parse_obj(configs)
 
 
 def _get_lsstdoc_configuration(path: str) -> Dict[str, Any]:
@@ -347,8 +347,7 @@ class Configuration(BaseModel):
         ext = os.path.splitext(v)[-1]
         if ext.lower() != ".pdf":
             raise ValueError(
-                "--pdf-path must be a PDF. "
-                "The detected extension is {}".format(ext)
+                f"--pdf-path must be a PDF. The detected extension is {ext}"
             )
 
         return v
@@ -396,6 +395,31 @@ class Configuration(BaseModel):
             v.plain = v.html
 
         return v
+
+    @validator("build_datetime", pre=True)
+    def validate_build_datetime(cls, v: Any) -> datetime.datetime:
+        """Validate and convert build_datetime field."""
+        if isinstance(v, str):
+            # Try ISO datetime format first (YYYY-MM-DDTHH:MM:SS or variations)
+            try:
+                return datetime.datetime.fromisoformat(v)
+            except ValueError:
+                pass
+
+            # Fall back to ISO date format (YYYY-MM-DD)
+            try:
+                return datetime.datetime.strptime(v, "%Y-%m-%d")
+            except ValueError:
+                raise ValueError(
+                    f"Invalid date format: {v}. Expected ISO datetime format "
+                    "(YYYY-MM-DDTHH:MM:SS) or ISO date format (YYYY-MM-DD)."
+                )
+        elif isinstance(v, datetime.datetime):
+            return v
+        else:
+            raise ValueError(
+                f"build_datetime must be a string or datetime, got {type(v)}"
+            )
 
     @root_validator
     def validate_git_ref(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/lander/main.py
+++ b/src/lander/main.py
@@ -180,7 +180,7 @@ def main(
     if github_sha:
         cli_configs["git_sha"] = github_sha
     if date:
-        cli_configs["date"] = date
+        cli_configs["build_datetime"] = date  # match config field name
 
     # Create the finalized Configuration that compiles information from
     # the CLI and also document metadata.

--- a/src/lander/renderer.py
+++ b/src/lander/renderer.py
@@ -10,7 +10,7 @@ __all__ = [
 import datetime
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import jinja2
 import markupsafe
@@ -45,8 +45,10 @@ def render_homepage(config: "Configuration", env: jinja2.Environment) -> str:
     return rendered_page
 
 
-def filter_simple_date(value: datetime.datetime) -> str:
-    """Filter a `datetime.datetime` into a 'YYYY-MM-DD' string."""
+def filter_simple_date(value: Union[datetime.datetime, datetime.date]) -> str:
+    """Filter a `datetime.datetime` or `datetime.date` into a
+    'YYYY-MM-DD' string.
+    """
     return value.strftime("%Y-%m-%d")
 
 


### PR DESCRIPTION
Apply Black formatter settings in VSCode, add setuptools as a dependency for pkg_resources, and correct the date metadata handling from the command line to ensure proper conversion to datetime. Enhance the filter function to accept both date and datetime types.