### PR TITLE
DM-52476: Add technote-style bibliographic metadata to Lander 1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ _build
 _tests
 
 .mypy_cache
+
+.claude/settings.local.json

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Change Log
 ##########
 
+1.1.0 (2025-09-22)
+==================
+
+- Generate meta tags and microdata consistent with the `Technote project <https://technote.lsst.io/user-guide/metadata.html>`__:
+
+  - Highwire Press metadata supported by Google Scholar
+  - OpenGraph metadata for additional social media support
+  - microformats2 metadata on HTML elements
+
+  These changes improve compatibility for Ook to ingest Lander landing pages.
+
 1.0.9 (2025-09-09)
 ==================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# Claude Configuration for Lander
+
+This is an HTML landing page generator for LSST PDF documentation. It's a Python project with Node.js/Webpack for frontend asset building.
+
+## Commands
+
+Run tests:
+```bash
+make test
+```
+
+Run Python unit tests only:
+```bash
+make pytest
+```
+
+Build frontend assets:
+```bash
+npm run build
+```
+
+## Project Structure
+
+- `src/lander/` - Python source code
+- `tests/` - Python unit tests
+- `integration-tests/` - End-to-end integration tests
+- `js/`, `scss/` - Frontend source files
+- `gulpfile.js`, `webpack.config.js` - Build configuration
+
+## Development Notes
+
+- Python package managed with setuptools
+- Frontend assets built with Webpack and Gulp
+- Uses pytest for unit testing
+- Integration tests in bash scripts
+- Code formatting with black (79 char line length)
+- Import sorting with isort

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,34 @@ This is an HTML landing page generator for LSST PDF documentation. It's a Python
 
 ## Commands
 
-Run tests:
-```bash
-make test
-```
-
-Run Python unit tests only:
-```bash
-make pytest
-```
-
 Build frontend assets:
+
 ```bash
 npm run build
+```
+
+Run tests:
+
+```bash
+tox run -e py
+```
+
+Run linting/formatting:
+
+```bash
+tox run -e lint
+```
+
+Run type checking:
+
+```bash
+tox run -e typing
+```
+
+Run end-to-end integration tests:
+
+```bash
+make test
 ```
 
 ## Project Structure

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 test: pytest ldm151 dmtn070
 
 pytest:
-	pytest --flake8 --doctest-modules lander tests
+	tox
 
 ldm151:
 	# End-to-end smoke integration test with LDM-151

--- a/src/lander/config.py
+++ b/src/lander/config.py
@@ -338,6 +338,23 @@ class Configuration(BaseModel):
 
         return data
 
+    @property
+    def canonical_url(self) -> Optional[str]:
+        """The canonical URL of the document.
+
+        This is the primary URL where the document can be accessed.
+        Prefers LSST the Docs URL, falls back to GitHub repository.
+        """
+        if self.ltd_product:
+            # Construct LSST the Docs URL from product slug
+            # Assumes we're building the main/default version
+            return f"https://{self.ltd_product}.lsst.io"  # noqa: E231
+        elif self.github_slug:
+            # Fall back to GitHub repository URL
+            return f"https://github.com/{self.github_slug}"  # noqa: E231
+        else:
+            return None
+
     @validator("pdf_path", always=True)
     def check_pdf_path(cls, v: str) -> str:
         """Validate the pdf_path field."""

--- a/src/lander/metadata/__init__.py
+++ b/src/lander/metadata/__init__.py
@@ -1,0 +1,6 @@
+"""Metadata formatting modules for HTML output."""
+
+__all__ = ["HighwireMetadata", "OpenGraphMetadata"]
+
+from .highwire import HighwireMetadata
+from .opengraph import OpenGraphMetadata

--- a/src/lander/metadata/base.py
+++ b/src/lander/metadata/base.py
@@ -1,0 +1,37 @@
+"""Base class for metadata formatters."""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, Union
+
+
+class MetaTagFormatterBase(ABC):
+    """A base class for generating HTML meta tags."""
+
+    def __str__(self) -> str:
+        """Create the metadata tags."""
+        return self.as_html()
+
+    @property
+    @abstractmethod
+    def tag_attributes(self) -> List[str]:
+        """The names of class properties that create tags."""
+        raise NotImplementedError
+
+    def as_html(self) -> str:
+        """Create the metadata HTML tags."""
+        tags: List[str] = []
+        for prop in self.tag_attributes:
+            self.extend_not_none(tags, getattr(self, prop))
+        return "\n".join(tags) + "\n"
+
+    @staticmethod
+    def extend_not_none(
+        entries: List[str], new_item: Optional[Union[str, List[str]]]
+    ) -> None:
+        """Extend a list with new items if they are not None."""
+        if new_item is None:
+            return
+        if isinstance(new_item, list):
+            entries.extend(new_item)
+        else:
+            entries.append(new_item)

--- a/src/lander/metadata/highwire.py
+++ b/src/lander/metadata/highwire.py
@@ -1,0 +1,107 @@
+"""Highwire Press metadata formatter for Google Scholar."""
+
+from typing import TYPE_CHECKING, List, Optional
+
+from .base import MetaTagFormatterBase
+
+if TYPE_CHECKING:
+    from lander.config import Configuration
+
+
+class HighwireMetadata(MetaTagFormatterBase):
+    """Format Lander metadata as Highwire Press tags for Google Scholar.
+
+    Highwire Press metadata tags are used by Google Scholar to index
+    academic and technical documents.
+    """
+
+    def __init__(self, config: "Configuration") -> None:
+        self.config = config
+
+    @property
+    def tag_attributes(self) -> List[str]:
+        """The names of class properties that create tags."""
+        return [
+            "title",
+            "authors",
+            "date",
+            "technical_report_number",
+            "pdf_url",
+            "fulltext_html_url",
+        ]
+
+    @property
+    def title(self) -> str:
+        """The document title tag."""
+        title = self.config.title.plain or self.config.title.html or ""
+        return f'<meta name="citation_title" content="{self._escape(title)}">'
+
+    @property
+    def authors(self) -> List[str]:
+        """Author metadata tags.
+
+        Each author generates multiple tags:
+        - citation_author
+        - citation_author_institution (if available)
+        - citation_author_email (if available)
+        - citation_author_orcid (if available)
+        """
+        if not self.config.authors:
+            return []
+
+        tags = []
+        for author in self.config.authors:
+            name = author.plain or author.html or ""
+            tags.append(
+                f'<meta name="citation_author" content="{self._escape(name)}">'
+            )
+            # Note: Institution, email, ORCID not currently in Lander config
+            # but included here for future extension
+        return tags
+
+    @property
+    def date(self) -> Optional[str]:
+        """The publication date tag.
+
+        Format: YYYY/MM/DD (Highwire requires slash separators)
+        """
+        if self.config.build_datetime:
+            date_str = self.config.build_datetime.strftime("%Y/%m/%d")
+            return f'<meta name="citation_date" content="{date_str}">'
+        return None
+
+    @property
+    def technical_report_number(self) -> Optional[str]:
+        """The technical report number (document handle)."""
+        if self.config.handle:
+            return (
+                f'<meta name="citation_technical_report_number" '
+                f'content="{self._escape(self.config.handle)}">'
+            )
+        return None
+
+    @property
+    def pdf_url(self) -> Optional[str]:
+        """The PDF download URL."""
+        if self.config.canonical_url and self.config.pdf_path:
+            pdf_url = (
+                f"{self.config.canonical_url}/"
+                f"{self.config.relative_pdf_path}"
+            )
+            return f'<meta name="citation_pdf_url" content="{pdf_url}">'
+        return None
+
+    @property
+    def fulltext_html_url(self) -> Optional[str]:
+        """The canonical HTML URL of the document."""
+        if self.config.canonical_url:
+            return (
+                f'<meta name="citation_fulltext_html_url" '
+                f'content="{self.config.canonical_url}">'
+            )
+        return None
+
+    @staticmethod
+    def _escape(value: str) -> str:
+        """Escape HTML attribute content."""
+        return value.replace('"', "&quot;").replace("'", "&#39;")

--- a/src/lander/metadata/opengraph.py
+++ b/src/lander/metadata/opengraph.py
@@ -1,0 +1,116 @@
+"""OpenGraph metadata formatter for social media."""
+
+from datetime import timezone
+from typing import TYPE_CHECKING, List, Optional
+
+from .base import MetaTagFormatterBase
+
+if TYPE_CHECKING:
+    from lander.config import Configuration
+
+
+class OpenGraphMetadata(MetaTagFormatterBase):
+    """Format Lander metadata as OpenGraph tags for social media.
+
+    OpenGraph metadata enables rich link previews in social media
+    platforms and messaging applications.
+    """
+
+    def __init__(self, config: "Configuration") -> None:
+        self.config = config
+
+    @property
+    def tag_attributes(self) -> List[str]:
+        """The names of class properties that create tags."""
+        return [
+            "title",
+            "description",
+            "url",
+            "og_type",
+            "authors",
+            "dates",
+        ]
+
+    @property
+    def title(self) -> str:
+        """The og:title tag."""
+        title = self.config.title.plain or self.config.title.html or ""
+        return (
+            f'<meta property="og:title" '  # noqa: E231
+            f'content="{self._escape(title)}">'
+        )
+
+    @property
+    def description(self) -> Optional[str]:
+        """The og:description tag from the abstract."""
+        if self.config.abstract:
+            abstract = (
+                self.config.abstract.plain or self.config.abstract.html or ""
+            )
+            return (
+                f'<meta property="og:description" '  # noqa: E231
+                f'content="{self._escape(abstract)}">'
+            )
+        return None
+
+    @property
+    def url(self) -> Optional[str]:
+        """The og:url canonical URL tag."""
+        if self.config.canonical_url:
+            return (  # noqa: E231
+                f'<meta property="og:url" '  # noqa: E231
+                f'content="{self.config.canonical_url}">'
+            )
+        return None
+
+    @property
+    def og_type(self) -> str:
+        """The og:type tag (always 'article' for documents)."""
+        return '<meta property="og:type" content="article">'
+
+    @property
+    def authors(self) -> List[str]:
+        """The og:article:author tags."""
+        if not self.config.authors:
+            return []
+
+        tags = []
+        for author in self.config.authors:
+            name = author.plain or author.html or ""
+            tags.append(
+                f'<meta property="og:article:author" '  # noqa: E231
+                f'content="{self._escape(name)}">'
+            )
+        return tags
+
+    @property
+    def dates(self) -> List[str]:
+        """Publication and modification time tags.
+
+        Format: ISO 8601 with timezone (YYYY-MM-DDTHH:MM:SSZ)
+        """
+        tags = []
+        if self.config.build_datetime:
+            # Ensure datetime has timezone info
+            dt = self.config.build_datetime
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            dt_str = dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+            tags.append(
+                f'<meta property="og:article:published_time" '  # noqa: E231
+                f'content="{dt_str}">'
+            )
+            # Also use as modified time since we don't track separate
+            # modification dates
+            tags.append(
+                f'<meta property="og:article:modified_time" '  # noqa: E231
+                f'content="{dt_str}">'
+            )
+
+        return tags
+
+    @staticmethod
+    def _escape(value: str) -> str:
+        """Escape HTML attribute content."""
+        return value.replace('"', "&quot;").replace("'", "&#39;")

--- a/src/lander/renderer.py
+++ b/src/lander/renderer.py
@@ -15,6 +15,9 @@ from typing import TYPE_CHECKING, Union
 import jinja2
 import markupsafe
 
+from lander import __version__
+from lander.metadata import HighwireMetadata, OpenGraphMetadata
+
 if TYPE_CHECKING:
     from lander.config import Configuration
 
@@ -39,9 +42,18 @@ def create_jinja_env() -> jinja2.Environment:
 
 
 def render_homepage(config: "Configuration", env: jinja2.Environment) -> str:
-    """Render the homepage.jinja template."""
+    """Render the homepage.jinja template with metadata."""
+    # Generate metadata
+    highwire = HighwireMetadata(config)
+    opengraph = OpenGraphMetadata(config)
+
     template = env.get_template("homepage.jinja")
-    rendered_page = template.render(config=config)
+    rendered_page = template.render(
+        config=config,
+        lander_version=__version__,
+        highwire_metadata=highwire.as_html(),
+        opengraph_metadata=opengraph.as_html(),
+    )
     return rendered_page
 
 

--- a/src/lander/templates/_info-panel.jinja
+++ b/src/lander/templates/_info-panel.jinja
@@ -7,14 +7,16 @@
     {% endif %}
   </span>
   {% endif %}
-  <h1 class="lander-info-header__product-name">{{ config.title.html|safe }}</h1>
+  <h1 class="lander-info-header__product-name p-name">{{ config.title.html|safe }}</h1>
 
   <ul class="o-list-bare">
     <li>
       <span class="svg-icon svg-icon--left svg-baseline">
         <svg><use xlink:href="#octicon-calendar" /></svg>
       </span>
-      {{ config.build_datetime|simple_date }}
+      <time class="dt-published" datetime="{{ config.build_datetime.isoformat() }}">
+        {{ config.build_datetime|simple_date }}
+      </time>
     </li>
 
     <li>
@@ -37,7 +39,7 @@
         {% if config.ltd_product %}
         {# LSST the Docs version switcher button #}
         <li class="c-lander-btn-row__item">
-          <a class="c-btn c-btn--small c-btn--ghost c-btn--ghost-faint" href="https://{{ config.ltd_product }}.lsst.io/v">Change version</a>
+          <a class="c-btn c-btn--small c-btn--ghost c-btn--ghost-faint u-url" href="https://{{ config.ltd_product }}.lsst.io/v">Change version</a>
         </li>
         {% endif %}
 
@@ -57,14 +59,14 @@
 <section class="lander-info-authors">
   <ul class='comma-list'>
   {% for author_name in config.authors %}
-    <li>{{ author_name.html|safe }}</li>
+    <li class="p-author">{{ author_name.html|safe }}</li>
   {% endfor %}
   </ul>
 </section>
 {% endif %}
 
 {% if config.abstract %}
-<section class="lander-info-abstract">
+<section class="lander-info-abstract p-summary">
   <h2 class="lander-subsection-header">Abstract</h2>
   {{ config.abstract.html|safe }}
 </section>
@@ -103,7 +105,7 @@
   <ul class="o-list-bare">
     {% if config.github_slug %}
     <li class="o-list-bare__item">
-      <a class="hidden-link" href="https://github.com/{{ config.github_slug }}">
+      <a class="hidden-link" href="https://github.com/{{ config.github_slug }}" data-lander-source-url="https://github.com/{{ config.github_slug }}">
         <span class="svg-icon svg-icon--left svg-baseline">
           <svg><use xlink:href="#octicon-mark-github" /></svg>
         </span>

--- a/src/lander/templates/base.jinja
+++ b/src/lander/templates/base.jinja
@@ -9,6 +9,21 @@
   <meta name="description" content="{{ config.abstract.plain }}">
   {% endif %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  {# Generator meta tag #}
+  <meta name="generator" content="Lander {{ lander_version }}">
+
+  {# Canonical URL #}
+  {% if config.canonical_url %}
+  <link rel="canonical" href="{{ config.canonical_url }}">
+  {% endif %}
+
+  {# OpenGraph metadata for social media #}
+  {{ opengraph_metadata }}
+
+  {# Highwire metadata for Google Scholar #}
+  {{ highwire_metadata }}
+
   {% include "_typekit_loader.jinja" %}
   <link rel="stylesheet" href="assets/app.css">
 </head>

--- a/src/lander/templates/homepage.jinja
+++ b/src/lander/templates/homepage.jinja
@@ -2,13 +2,13 @@
 
 {% block body %}
 
-<div class="lander-container lander-container--content">
+<div class="lander-container lander-container--content h-entry">
 
   <div class="lander-info-item">
     {% include "_info-panel.jinja" %}
   </div>
 
-  <div class="lander-pdf-item">
+  <div class="lander-pdf-item e-content">
     <div id="pdf-container" data-pdf-path="{{ config.relative_pdf_path }}">
     </div>
   </div>

--- a/tests/fixtures/test.pdf
+++ b/tests/fixtures/test.pdf
@@ -1,0 +1,35 @@
+%PDF-1.4
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [3 0 R]
+/Count 1
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [0 0 612 792]
+>>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000079 00000 n 
+0000000173 00000 n 
+trailer
+<<
+/Size 4
+/Root 1 0 R
+>>
+startxref
+301
+%%EOF

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,157 @@
+"""Tests for metadata generation."""
+
+import datetime
+import os
+
+from lander.config import Configuration, EncodedString
+from lander.metadata.highwire import HighwireMetadata
+from lander.metadata.opengraph import OpenGraphMetadata
+
+# Path to test fixtures
+TEST_PDF_PATH = os.path.join(os.path.dirname(__file__), "fixtures", "test.pdf")
+
+
+def test_highwire_metadata() -> None:
+    """Test Highwire metadata generation."""
+    config = Configuration(
+        build_dir="build",
+        pdf_path=TEST_PDF_PATH,
+        title=EncodedString(plain="Test Document", html="Test Document"),
+        abstract=EncodedString(
+            plain="This is a test abstract.",
+            html="<p>This is a test abstract.</p>",
+        ),
+        handle="TEST-001",
+        authors=[
+            EncodedString(plain="John Doe", html="John Doe"),
+            EncodedString(plain="Jane Smith", html="Jane Smith"),
+        ],
+        build_datetime=datetime.datetime(2024, 1, 15, 12, 0, 0),
+        github_slug="lsst/test-repo",
+        ltd_product="test-001",
+    )
+
+    metadata = HighwireMetadata(config)
+    html = metadata.as_html()
+
+    # Check for required tags
+    assert "citation_title" in html
+    assert "citation_author" in html
+    assert "citation_date" in html
+    assert "citation_technical_report_number" in html
+    assert "TEST-001" in html
+    assert "2024/01/15" in html
+
+
+def test_opengraph_metadata() -> None:
+    """Test OpenGraph metadata generation."""
+    config = Configuration(
+        build_dir="build",
+        pdf_path=TEST_PDF_PATH,
+        title=EncodedString(plain="Test Document", html="Test Document"),
+        abstract=EncodedString(
+            plain="This is a test abstract.",
+            html="<p>This is a test abstract.</p>",
+        ),
+        build_datetime=datetime.datetime(2024, 1, 15, 12, 0, 0),
+        github_slug="lsst/test-repo",
+        ltd_product="test-001",
+    )
+
+    metadata = OpenGraphMetadata(config)
+    html = metadata.as_html()
+
+    # Check for required tags
+    assert "og:title" in html
+    assert "og:description" in html
+    assert "og:url" in html
+    assert "og:type" in html
+    assert "article" in html
+    assert "2024-01-15T12:00:00Z" in html
+
+
+def test_canonical_url_generation() -> None:
+    """Test canonical URL generation."""
+    # Test with LTD product
+    config_ltd = Configuration(
+        build_dir="build",
+        pdf_path=TEST_PDF_PATH,
+        title=EncodedString(plain="Test Document", html="Test Document"),
+        ltd_product="test-001",
+    )
+    assert config_ltd.canonical_url == "https://test-001.lsst.io"
+
+    # Test with GitHub slug fallback
+    config_github = Configuration(
+        build_dir="build",
+        pdf_path=TEST_PDF_PATH,
+        title=EncodedString(plain="Test Document", html="Test Document"),
+        github_slug="lsst/test-repo",
+    )
+    assert config_github.canonical_url == "https://github.com/lsst/test-repo"
+
+    # Test with neither
+    config_none = Configuration(
+        build_dir="build",
+        pdf_path=TEST_PDF_PATH,
+        title=EncodedString(plain="Test Document", html="Test Document"),
+    )
+    assert config_none.canonical_url is None
+
+
+def test_metadata_escaping() -> None:
+    """Test that HTML content is properly escaped."""
+    config = Configuration(
+        build_dir="build",
+        pdf_path=TEST_PDF_PATH,
+        title=EncodedString(
+            plain="Title with \"quotes\" and 'apostrophes'", html="Title"
+        ),
+        abstract=EncodedString(
+            plain="Abstract with \"quotes\" and 'apostrophes'",
+            html="<p>Abstract</p>",
+        ),
+        authors=[
+            EncodedString(plain='Author "Name"', html="Author Name"),
+        ],
+        github_slug="lsst/test-repo",
+    )
+
+    highwire = HighwireMetadata(config)
+    html = highwire.as_html()
+
+    # Check that quotes are escaped
+    assert "&quot;" in html
+    assert "&#39;" in html
+
+    # Check that unescaped quotes are not present in content attributes
+    assert 'content="Title with "quotes"' not in html
+    assert "content='Title with 'apostrophes'" not in html
+
+
+def test_metadata_with_missing_fields() -> None:
+    """Test metadata generation with minimal configuration."""
+    config = Configuration(
+        build_dir="build",
+        pdf_path=TEST_PDF_PATH,
+        title=EncodedString(plain="Minimal Document", html="Minimal Document"),
+    )
+
+    highwire = HighwireMetadata(config)
+    html = highwire.as_html()
+
+    # Should have title and date (auto-generated) but not other optional fields
+    assert "citation_title" in html
+    assert "citation_date" in html  # This will be auto-generated
+    assert "citation_author" not in html
+    assert "citation_technical_report_number" not in html
+
+    opengraph = OpenGraphMetadata(config)
+    html = opengraph.as_html()
+
+    # Should have title, type and dates but not other optional fields
+    assert "og:title" in html
+    assert "og:type" in html
+    assert "og:article:published_time" in html  # This will be auto-generated
+    assert "og:description" not in html
+    assert "og:url" not in html


### PR DESCRIPTION
Implements technote-style (https://technote.lsst.io/user-guide/metadata.html) metadata tags to enable:

- Google Scholar indexing via Highwire Press metadata
- Rich social media previews via OpenGraph metadata
- Semantic HTML markup via microformats2 classes
- SEO improvements with canonical URLs and generator tags

Besides being good for the semantic web, this change will also allow Ook to extract metadata from Lander PDF documents with the same or similar patterns as it uses for Sphinx-based technotes.

Key changes:
- New metadata/ module with Highwire and OpenGraph formatters
- Added canonical_url property to Configuration class
- Updated HTML templates with metadata tags and semantic markup
- Enhanced renderer to generate and inject metadata
- Comprehensive test coverage for all metadata functionality