### PR TITLE
DM-55688: Point periodic CI at the 1.0 maintenance branch

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -1,6 +1,13 @@
 # This is a separate run of the Python test suite that doesn't cache the tox
 # environment and runs from a schedule.  The purpose is to test compatibility
 # with the latest versions of dependencies.
+#
+# This workflow definition has to live on the default branch (main) because
+# GitHub only fires `schedule:` triggers from the default branch.  The code
+# that is actually released and deployed lives on the 1.0 maintenance branch,
+# so every job here explicitly checks out `ref: "1.0"`.  The Python version
+# matrix below therefore mirrors the one in 1.0's own .github/workflows/ci.yaml
+# rather than anything on main.
 
 name: Periodic CI
 
@@ -8,7 +15,7 @@ env:
   # Default Python version used for all jobs other than test, which uses a
   # matrix of supported versions. Quote the version to avoid interpretation as
   # a floating point number.
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.13"
 
 "on":
   schedule:
@@ -23,11 +30,17 @@ jobs:
     strategy:
       matrix:
         python:
+          - "3.8"
+          - "3.9"
+          - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "1.0"
 
       - name: Set up node
         uses: actions/setup-node@v4
@@ -68,6 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: "1.0"
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Set up node

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,13 @@ commands = pre-commit run --all-files
 
 [testenv:typing]
 description = Run mypy.
+# main is a frozen maintenance branch (development happens on 1.0), so
+# unpinned type-checking tooling re-breaks CI on every upstream release.
+# beautifulsoup4 4.13 added inline annotations the frozen tests don't guard
+# against, hence the bounded pins here.
 deps =
-    mypy
+    mypy>=2.3,<2.4
+    beautifulsoup4>=4.12,<4.13
 commands =
     mypy src/lander tests
 


### PR DESCRIPTION
## Summary

The scheduled Periodic CI workflow has been testing `main`, which is effectively abandoned (tip 2024-11-21). All development and releases happen on the **`1.0` maintenance branch** — tip 2026-07-28, which the 1.2.0 release tags, and the 1.x line is what Rubin deploys. The periodic run was therefore reporting dependency-compatibility status for code nobody ships.

This points both jobs at the branch that is actually shipped:

```yaml
- uses: actions/checkout@v4
  with:
    ref: "1.0"
```

## Why the workflow stays on `main`

GitHub only fires `schedule:` triggers from the **default branch**, so the cron definition cannot be moved to `1.0` and still run. The definition has to live on `main` while the code under test lives on `1.0` — hence the explicit `ref`, plus a comment at the top of the file recording the constraint so this doesn't look like an accident later.

`periodic-ci.yaml` exists only on `main`; the `1.0` branch has just `ci.yaml`.

## Python matrix

Refreshed to mirror what `1.0` actually supports, rather than what `main` last believed:

| | before (`main`) | after (from `1.0`) |
|---|---|---|
| `PYTHON_VERSION` | `"3.12"` | `"3.13"` |
| test matrix | `3.11`, `3.12` | `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13` |

Evidence, all read from the `1.0` branch:

- `setup.cfg` — `python_requires = >=3.8`, with classifiers for 3.8 through 3.13. (Note `1.0`'s `pyproject.toml` has no `[project]` table; packaging metadata is still in `setup.cfg`.)
- `.github/workflows/ci.yaml` — test matrix is `["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]`, and the `lint` job pins `3.13`, which is where the new `PYTHON_VERSION` default comes from.

That matrix is not theoretical: `1.0`'s CI passed green on all six versions on 2026-07-28.

## After merge: the workflow needs re-enabling

Periodic CI is currently **`disabled_inactivity`** — GitHub disables cron workflows after 60 days idle, and merging this PR will *not* revive it. It must be re-enabled explicitly:

```
gh workflow enable "Periodic CI" --repo lsst-sqre/lander
```

## One caveat worth flagging

`1.0`'s `ci.yaml` downloads and installs pandoc (2.19.2) before running `tox -e py`; `periodic-ci.yaml` has no such step, since `main`'s tests never needed it. The first periodic run against `1.0` may therefore fail for reasons unrelated to dependency drift. I left that out of scope here so this change stays reviewable as one idea — worth a follow-up once we see a real run.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/periodic-ci.yaml'))"` parses; `schedule`/`workflow_dispatch` triggers and the `0 12 * * 1` cron are unchanged.
- Both `actions/checkout` steps confirmed to carry `ref: "1.0"` after parsing, with the existing `fetch-depth: 0` preserved on `test-packaging` for setuptools_scm.

## References

- Jira: [DM-55688](https://rubinobs.atlassian.net/browse/DM-55688)

[DM-55688]: https://rubinobs.atlassian.net/browse/DM-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ